### PR TITLE
Fix composer deprecation warning about uppercase characters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": "^7.2",
         "ext-curl": "*",
         "league/omnipay": "^3.0",
-        "omnipay/WorldPay": "^3.0"
+        "omnipay/worldpay": "^3.0"
     },
     "require-dev": {
         "automattic/vipwpcs": "^0.3.0",


### PR DESCRIPTION
```
Deprecation warning: require.omnipay/WorldPay is invalid, it should not contain uppercase characters. Please use omnipay/worldpay instead. Make sure you fix this as Composer 2.0 will error.
```